### PR TITLE
Fixes issue 69 - use Cargo version of wasm-bindgen to better ensure not-broken build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ if you want to publish packages, you'll also need an account on [npm] and have
     crate-type = ["cdylib"]
 
     [dependencies]
-    wasm-bindgen = { git = 'https://github.com/alexcrichton/wasm-bindgen' }
+    wasm-bindgen = "0.1"
   ```
 3. add this to the top of your `src/lib.rs`:
 

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -12,8 +12,7 @@ pub fn cargo_install_wasm_bindgen() {
     let pb = progressbar::new(step);
     let _output = Command::new("cargo")
         .arg("install")
-        .arg("--git")
-        .arg("https://github.com/alexcrichton/wasm-bindgen")
+        .arg("wasm-bindgen")
         .output()
         .unwrap_or_else(|e| panic!("{} failed to execute process: {}", emoji::ERROR, e));
     pb.finish();


### PR DESCRIPTION
fixes #69 

Change references to wasm-bindgen from pointing at git repo to pointing at crates.io