### PR TITLE
fix(refactor): read cargo file just once and store in variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,25 @@ pub mod progressbar;
 pub mod readme;
 
 use std::fs;
+use std::fs::File;
+use std::io::Read;
 
 use console::style;
 use failure::Error;
 use progressbar::ProgressOutput;
 
+fn read_cargo_toml_to_string() -> String {
+    let mut cargo_file = File::open("Cargo.toml").expect("Unable to open Cargo.toml");
+    let mut cargo_contents = String::new();
+    cargo_file.read_to_string(&mut cargo_contents).expect("Failed to read Cargo.toml");
+
+    return cargo_contents;
+}
+
 lazy_static! {
     pub static ref PBAR: ProgressOutput = { ProgressOutput::new() };
+    
+    pub static ref CARGO_TOML: String = read_cargo_toml_to_string();
 }
 
 pub fn create_pkg_dir(path: &str) -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,14 +45,15 @@ main!(|args: Cli, log_level: verbosity| match args.cmd {
             Some(p) => p,
             None => ".".to_string(),
         };
-
+        
         build::rustup_add_wasm_target();
         build::cargo_build_wasm(&crate_path);
         wasm_pack::create_pkg_dir(&crate_path)?;
         manifest::write_package_json(&crate_path, scope)?;
         readme::copy_from_crate(&crate_path)?;
         bindgen::cargo_install_wasm_bindgen();
-        let name = manifest::get_crate_name(&crate_path)?;
+        let name = manifest::get_crate_name()?;
+        // let name = manifest::get_crate_name(&crate_path)?;
         bindgen::wasm_bindgen_build(&crate_path, &name);
         PBAR.one_off_message(&format!(
             "{} Done in {}",

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use PBAR;
+use CARGO_TOML;
 use console::style;
 use emoji;
 use failure::Error;
@@ -41,14 +42,14 @@ struct Repository {
     url: String,
 }
 
-fn read_cargo_toml(path: &str) -> Result<CargoManifest, Error> {
-    let manifest_path = format!("{}/Cargo.toml", path);
-    let mut cargo_file = File::open(manifest_path)?;
-    let mut cargo_contents = String::new();
-    cargo_file.read_to_string(&mut cargo_contents)?;
+// fn read_cargo_toml(path: &str) -> Result<CargoManifest, Error> {
+//     let manifest_path = format!("{}/Cargo.toml", path);
+//     let mut cargo_file = File::open(manifest_path)?;
+//     let mut cargo_contents = String::new();
+//     cargo_file.read_to_string(&mut cargo_contents)?;
 
-    Ok(toml::from_str(&cargo_contents)?)
-}
+//     Ok(toml::from_str(&cargo_contents)?)
+// }
 
 impl CargoManifest {
     fn into_npm(mut self, scope: Option<String>) -> NpmPackage {
@@ -91,7 +92,7 @@ pub fn write_package_json(path: &str, scope: Option<String>) -> Result<(), Error
     let pb = PBAR.message(&step);
     let pkg_file_path = format!("{}/pkg/package.json", path);
     let mut pkg_file = File::create(pkg_file_path)?;
-    let crate_data = read_cargo_toml(path)?;
+    let crate_data: CargoManifest = toml::from_str(&CARGO_TOML.to_string())?;
     let npm_data = crate_data.into_npm(scope);
 
     if npm_data.description.is_none() {
@@ -110,6 +111,7 @@ pub fn write_package_json(path: &str, scope: Option<String>) -> Result<(), Error
     Ok(())
 }
 
-pub fn get_crate_name(path: &str) -> Result<String, Error> {
-    Ok(read_cargo_toml(path)?.package.name)
+pub fn get_crate_name() -> Result<String, Error> {
+    let crate_data: CargoManifest = toml::from_str(&CARGO_TOML.to_string())?;
+    Ok(crate_data.package.name)
 }


### PR DESCRIPTION
### What does this PR do?
This PR ensures that the cargo file is only read once and stored in a variable which then gets passed around.