### PR TITLE
Don't install wasm-bindgen if it already exists

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -3,8 +3,16 @@ use console::style;
 use emoji;
 use std::{env, fs, process::Command};
 
+#[cfg(target_family = "windows")]
+static PATH_SEP: &str = ";";
+
+#[cfg(not(target_family = "windows"))]
+static PATH_SEP: &str = ":";
+
 pub fn cargo_install_wasm_bindgen() {
-    if wasm_bindgen_installed() { return; }
+    if wasm_bindgen_installed() {
+        return;
+    }
     let step = format!(
         "{} {}Installing WASM-bindgen...",
         style("[6/7]").bold().dim(),
@@ -40,13 +48,13 @@ pub fn wasm_bindgen_build(path: &str, name: &str) {
 
 fn wasm_bindgen_installed() -> bool {
     if let Ok(path) = env::var("PATH") {
-        return path.split(":")
+        path.split(PATH_SEP)
             .map(|p: &str| -> bool {
-                let prog_str = format!("{}/{}", p, "wasm-bindgen");
+                let prog_str = format!("{}/wasm-bindgen", p);
                 fs::metadata(prog_str).is_ok()
             })
-            .fold(false, |res, b| res || b);
+            .fold(false, |res, b| res || b)
     } else {
-        return false;
+        false
     }
 }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,9 +1,10 @@
 use PBAR;
 use console::style;
 use emoji;
-use std::process::Command;
+use std::{env, fs, process::Command};
 
 pub fn cargo_install_wasm_bindgen() {
+    if wasm_bindgen_installed() { return; }
     let step = format!(
         "{} {}Installing WASM-bindgen...",
         style("[6/7]").bold().dim(),
@@ -35,4 +36,17 @@ pub fn wasm_bindgen_build(path: &str, name: &str) {
         .output()
         .unwrap_or_else(|e| panic!("{} failed to execute process: {}", emoji::ERROR, e));
     pb.finish();
+}
+
+fn wasm_bindgen_installed() -> bool {
+    if let Ok(path) = env::var("PATH") {
+        return path.split(":")
+            .map(|p: &str| -> bool {
+                let prog_str = format!("{}/{}", p, "wasm-bindgen");
+                fs::metadata(prog_str).is_ok()
+            })
+            .fold(false, |res, b| res || b);
+    } else {
+        return false;
+    }
 }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,7 +1,7 @@
-use PBAR;
 use console::style;
 use emoji;
 use std::{env, fs, process::Command};
+use PBAR;
 
 #[cfg(target_family = "windows")]
 static PATH_SEP: &str = ";";

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,7 @@
-use PBAR;
 use console::style;
 use emoji;
 use std::process::Command;
+use PBAR;
 
 pub fn rustup_add_wasm_target() {
     let step = format!(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,12 +1,12 @@
 use std::fs::File;
 use std::io::prelude::*;
 
-use PBAR;
 use console::style;
 use emoji;
 use failure::Error;
 use serde_json;
 use toml;
+use PBAR;
 
 #[derive(Deserialize)]
 struct CargoManifest {

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -2,8 +2,8 @@ use console::style;
 use failure::Error;
 use std::fs;
 
-use PBAR;
 use emoji;
+use PBAR;
 
 pub fn copy_from_crate(path: &str) -> Result<(), Error> {
     let step = format!(


### PR DESCRIPTION
I started working on some changes to try and fix the problems mentioned in #51. Per the discussion on that issue, I am opening up a PR so that the changes made can be reviewed and discussed. I don't think this is ready to merge _quite_ yet, but I have some questions about testing, cross-platform issues (specifically Windows), and general style.

This change adds a function called `wasm_bindgen_installed`, which will return a boolean value representing whether or not `wasm-bindgen` exists in the path. The `cargo_install_wasm_bindgen` will only progress to the installation process if `wasm_bindgen_installed` returns false.

## Questions:

### Testing

I am not exactly sure how to design test cases for this, since it depends on the environment. I did test this manually and things seemed to be working correctly, but ideally some test cases would make sure that this behaves correctly.

### Windows

Windows uses `;` as a path separator, in contrast to the `:` separator on Linux. Should I add a separator variable using the `cfg!` macro to set this accordingly? Are there other compatibility issues to consider aside from that?

### Style

Ashley sent me a link to [this] SO answer regarding how to check if a command is in the path, which I used as a starting point for this. The code below uses `map` and `fold` instead of a for loop as shown in the SO answer. Is there a preference regarding that? I do not mind rewriting this to follow an imperative style.

[this]: https://stackoverflow.com/questions/35045996/check-if-a-command-is-in-path-executable-as-process

P.S. Thank you for being welcoming to contributions! I am still a little new to helping out with open source projects, so I really appreciate it. :)


Update: The Travis build did not pass, this seems to have failed: `The command "cargo fmt -- --write-mode diff" exited with 4.` Is that a formatting issue?