### PR TITLE
Added notes on configuring rustfmt to contributing.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,58 @@
 This project is currently not ready for code contributions! However, please do
 take a look at the issue tracker. Issues marked "question" are excellent places
 to share feedback.
+
+## Submitting a PR
+
+Before you submit your pull request, check that you have completed all of the
+steps mentioned in the pull request template. Link the issue that your pull
+request is responding to, and format your code using [rustfmt][rustfmt].
+
+### Configuring rustfmt
+
+Before submitting code in a PR, make sure that you have formatted the codebase
+using [rustfmt][rustfmt]. `rustfmt` is a tool for formatting Rust code, which
+helps keep style consistent across the project. If you have not used `rustfmt`
+before, it is not too difficult.
+
+If you have not already configured `rustfmt` for the
+nightly toolchain, it can be done using the following steps:
+
+**1. Use Nightly Toolchain**
+
+Use the `rustup override` command to make sure that you are using the nightly
+toolchain. Run this command in the `wasm-pack` directory you cloned.
+
+```sh
+rustup override set nightly
+```
+
+**2. Add the rustfmt component**
+
+Install the most recent version of `rustfmt` using this command:
+
+```sh
+rustup component add rustfmt-preview --toolchain nightly
+```
+
+**3. Running rustfmt**
+
+To run `rustfmt`, use this command:
+
+```sh
+cargo +nightly fmt
+```
+
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
+
+## Conduct
+
+As mentioned in the readme file, this project is a part of the
+[rust-wasm][rust-wasm] group. As such, contributors should be sure to follow
+the rust-wasm group's [code of conduct][rust-wasm-coc], as well as the Rust
+language [code of conduct][rust-coc].
+
+[rust-wasm]: https://github.com/rust-lang-nursery/rust-wasm
+[rust-wasm-coc]:working://github.com/rust-lang-nursery/rust-wasm/blob/master/CODE_OF_CONDUCT.md
+[rust-coc]: https://www.rust-lang.org/en-US/conduct.html
+


### PR DESCRIPTION
This commit adds some documentation on how to configure `rustfmt` for the nightly toolchain, per issue 
#72. It covers how to install the formatter, and how to make sure that the codebase is properly formatted before submitting a PR.

I placed these notes in `CONTRIBUTING.md` rather than in the 'up and running' section, as it seemed like it might be too much information for the readme, and this mostly pertains to contributors if I understand this correctly? I don't mind moving this into the readme if you would prefer.

This also mentions the PR template that @mgattozzi added in pull #82, so this might need to land after that has been merged.

One other note, I added a link to the rust-wasm group's CoC for good measure, but I can remove that if it is out of the scope of this PR.
