### PR TITLE
feat(manifest): add main entry

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use console::style;
 use emoji;
 use failure::Error;
@@ -18,6 +19,10 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
+        if s.contains("already exists") {
+          PBAR.one_off_message("wasm-bindgen already installed");
+          return Ok(());
+        }
         PBAR.error("Installing wasm-bindgen failed");
         bail!(format!("Details:\n{}", s));
     } else {
@@ -46,6 +51,9 @@ pub fn wasm_bindgen_build(path: &str, name: &str) -> Result<(), Error> {
         PBAR.error("wasm-bindgen failed to execute properly");
         bail!(format!("Details:\n{}", s));
     } else {
+        let js_file = format!("{}/pkg/{}.js", path, binary_name);
+        let index_file = format!("{}/pkg/index.js", path);
+        fs::rename(&js_file, &index_file)?;
         Ok(())
     }
 }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,7 +1,7 @@
-use std::fs;
 use console::style;
 use emoji;
 use failure::Error;
+use std::fs;
 use std::process::Command;
 use PBAR;
 
@@ -20,8 +20,8 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
         if s.contains("already exists") {
-          PBAR.one_off_message("wasm-bindgen already installed");
-          return Ok(());
+            PBAR.one_off_message("wasm-bindgen already installed");
+            return Ok(());
         }
         PBAR.error("Installing wasm-bindgen failed");
         bail!(format!("Details:\n{}", s));

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -14,7 +14,7 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     let pb = PBAR.message(&step);
     let output = Command::new("cargo")
         .arg("install")
-        .arg("wasm-bindgen")
+        .arg("wasm-bindgen-cli")
         .output()?;
     pb.finish();
     if !output.status.success() {

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,8 +1,8 @@
-use PBAR;
 use console::style;
 use emoji;
 use failure::Error;
 use std::process::Command;
+use PBAR;
 
 pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     let step = format!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,8 +1,8 @@
-use PBAR;
 use console::style;
 use emoji;
 use failure::Error;
 use std::process::Command;
+use PBAR;
 
 pub fn rustup_add_wasm_target() -> Result<(), Error> {
     let step = format!(

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,3 @@
-use PBAR;
 use bindgen;
 use build;
 use console::style;
@@ -13,6 +12,7 @@ use readme;
 use std::fs;
 use std::result;
 use std::time::Instant;
+use PBAR;
 
 #[derive(Debug, StructOpt)]
 pub enum Command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ extern crate indicatif;
 extern crate quicli;
 
 use quicli::prelude::*;
-use wasm_pack::Cli;
 use wasm_pack::command::run_wasm_pack;
+use wasm_pack::Cli;
 
 main!(|args: Cli, log_level: verbosity| {
     run_wasm_pack(args.cmd)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -54,7 +54,6 @@ fn read_cargo_toml(path: &str) -> Result<CargoManifest, Error> {
 impl CargoManifest {
     fn into_npm(mut self, scope: Option<String>) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
-        let js_file = format!("{}.js", filename);
         let wasm_file = format!("{}_bg.wasm", filename);
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
@@ -69,8 +68,8 @@ impl CargoManifest {
                 ty: "git".to_string(),
                 url: repo_url,
             }),
-            files: vec![js_file.clone(), wasm_file],
-            main: js_file,
+            files: vec![wasm_file],
+            main: "index.js".to_string(),
         }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -32,6 +32,7 @@ struct NpmPackage {
     license: Option<String>,
     repository: Option<Repository>,
     files: Vec<String>,
+    main: String,
 }
 
 #[derive(Serialize)]
@@ -68,7 +69,8 @@ impl CargoManifest {
                 ty: "git".to_string(),
                 url: repo_url,
             }),
-            files: vec![js_file, wasm_file],
+            files: vec![js_file.clone(), wasm_file],
+            main: js_file,
         }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,12 +1,12 @@
 use std::fs::File;
 use std::io::prelude::*;
 
-use PBAR;
 use console::style;
 use emoji;
 use failure::Error;
 use serde_json;
 use toml;
+use PBAR;
 
 #[derive(Deserialize)]
 struct CargoManifest {

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,6 +1,6 @@
-use PBAR;
 use failure::Error;
 use std::process::Command;
+use PBAR;
 
 pub fn npm_pack(path: &str) -> Result<(), Error> {
     let pkg_file_path = format!("{}/pkg", path);

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -2,8 +2,8 @@ use console::style;
 use failure::Error;
 use std::fs;
 
-use PBAR;
 use emoji;
+use PBAR;
 
 pub fn copy_from_crate(path: &str) -> Result<(), Error> {
     let step = format!(

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -41,6 +41,7 @@ fn it_creates_a_package_json_default_path() {
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
     assert_eq!(pkg.files, ["wasm_pack.js", "wasm_pack_bg.wasm"]);
+    assert_eq!(pkg.main, "wasm_pack.js");
 }
 
 #[test]

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -40,8 +40,8 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack.js", "wasm_pack_bg.wasm"]);
-    assert_eq!(pkg.main, "wasm_pack.js");
+    assert_eq!(pkg.files, ["wasm_pack_bg.wasm"]);
+    assert_eq!(pkg.main, "index.js");
 }
 
 #[test]
@@ -54,7 +54,6 @@ fn it_creates_a_package_json_provided_path() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "js-hello-world");
-    assert_eq!(pkg.files, ["js_hello_world.js", "js_hello_world_bg.wasm"]);
 }
 
 #[test]
@@ -67,8 +66,4 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
-    assert_eq!(
-        pkg.files,
-        ["scopes_hello_world.js", "scopes_hello_world_bg.wasm"]
-    );
 }

--- a/tests/manifest/utils.rs
+++ b/tests/manifest/utils.rs
@@ -12,6 +12,7 @@ pub struct NpmPackage {
     pub license: String,
     pub repository: Repository,
     pub files: Vec<String>,
+    pub main: String,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
fixes #94 

this PR does a few things:

- adds a step to the `wasm_bindgen` run that renames the generated js file to `index.js`
- adds a `main` entry to the `package.json` that points to `index.js`
- removes the js file from the files entry since it's preservation in the package is cover by being in the `main` entry
- removes redundant/unnecessary checks on `package.json` contents in some tests