### PR TITLE
Wrap npm adduser

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -156,7 +156,7 @@ fn login(
 
     npm::npm_login(&registry, &scope, always_auth, &auth_type)?;
 
-    PBAR.message(&format!("👋  logged you in to {}!", registry));
+    PBAR.message(&format!("👋  logged you in!"));
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -32,9 +32,9 @@ pub enum Command {
     /// 🎆  pack up your npm package and publish! [NOT IMPLEMENTED]
     Publish { path: Option<String> },
 
-    #[structopt(name = "adduser", alias = "login", alias = "add-user")]
-    /// 👤  Add a registry user account! [NOT IMPLEMENTED]
-    Adduser {
+    #[structopt(name = "login", alias = "adduser", alias = "add-user")]
+    /// 👤  Add a registry user account! (aliases: adduser, add-user) [NOT IMPLEMENTED]
+    Login {
         #[structopt(long = "registry", short = "r")]
         /// Default: 'https://registry.npmjs.org/'.
         /// The base URL of the npm package registry. If scope is also specified, this registry will only be used for packages with that scope. scope defaults to the scope of the project directory you're currently in, if any.
@@ -64,12 +64,12 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
         Command::Init { path, scope } => init(path, scope),
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
-        Command::Adduser {
+        Command::Login {
             registry,
             scope,
             always_auth,
             auth_type,
-        } => adduser(registry, scope, always_auth, auth_type),
+        } => login(registry, scope, always_auth, auth_type),
     };
 
     match status {
@@ -146,15 +146,15 @@ fn publish(path: Option<String>) -> result::Result<(), Error> {
     Ok(())
 }
 
-fn adduser(
+fn login(
     registry: Option<String>,
     scope: Option<String>,
     always_auth: bool,
     auth_type: Option<String>,
 ) -> result::Result<(), Error> {
-    npm::npm_adduser(registry, scope, always_auth, auth_type)?;
+    npm::npm_login(registry, scope, always_auth, auth_type)?;
 
-    PBAR.one_off_message("👋  added registry user account!");
+    PBAR.one_off_message("👋  logged you in!");
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -154,7 +154,7 @@ fn login(
 ) -> result::Result<(), Error> {
     npm::npm_login(registry, scope, always_auth, auth_type)?;
 
-    PBAR.one_off_message("👋  logged you in!");
+    PBAR.message("👋  logged you in!");
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -23,12 +23,38 @@ pub enum Command {
         #[structopt(long = "scope", short = "s")]
         scope: Option<String>,
     },
+
     #[structopt(name = "pack")]
     /// 🍱  create a tar of your npm package but don't publish! [NOT IMPLEMENTED]
     Pack { path: Option<String> },
+
     #[structopt(name = "publish")]
     /// 🎆  pack up your npm package and publish! [NOT IMPLEMENTED]
     Publish { path: Option<String> },
+
+    #[structopt(name = "adduser", alias = "login", alias = "add-user")]
+    /// 👤  Add a registry user account! [NOT IMPLEMENTED]
+    Adduser {
+        #[structopt(long = "registry", short = "r")]
+        /// Default: 'https://registry.npmjs.org/'.
+        /// The base URL of the npm package registry. If scope is also specified, this registry will only be used for packages with that scope. scope defaults to the scope of the project directory you're currently in, if any.
+        registry: Option<String>,
+
+        #[structopt(long = "scope", short = "s")]
+        /// Default: none.
+        /// If specified, the user and login credentials given will be associated with the specified scope.
+        scope: Option<String>,
+
+        #[structopt(long = "always-auth", short = "a")]
+        /// If specified, save configuration indicating that all requests to the given registry should include authorization information. Useful for private registries. Can be used with --registry and / or --scope
+        always_auth: bool,
+
+        #[structopt(long = "auth-type", short = "t")]
+        /// Default: 'legacy'. 
+        /// Type: 'legacy', 'sso', 'saml', 'oauth'.
+        /// What authentication strategy to use with adduser/login. Some npm registries (for example, npmE) might support alternative auth strategies besides classic username/password entry in legacy npm.
+        auth_type: Option<String>,
+    },
 }
 
 pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
@@ -38,6 +64,12 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
         Command::Init { path, scope } => init(path, scope),
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
+        Command::Adduser {
+            registry,
+            scope,
+            always_auth,
+            auth_type,
+        } => adduser(registry, scope, always_auth, auth_type),
     };
 
     match status {
@@ -111,6 +143,18 @@ fn publish(path: Option<String>) -> result::Result<(), Error> {
 
     npm::npm_publish(&crate_path)?;
     PBAR.message("💥  published your package!");
+    Ok(())
+}
+
+fn adduser(
+    registry: Option<String>,
+    scope: Option<String>,
+    always_auth: bool,
+    auth_type: Option<String>,
+) -> result::Result<(), Error> {
+    npm::npm_adduser(registry, scope, always_auth, auth_type)?;
+
+    PBAR.one_off_message("👋  added registry user account!");
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -50,7 +50,7 @@ pub enum Command {
         always_auth: bool,
 
         #[structopt(long = "auth-type", short = "t")]
-        /// Default: 'legacy'. 
+        /// Default: 'legacy'.
         /// Type: 'legacy', 'sso', 'saml', 'oauth'.
         /// What authentication strategy to use with adduser/login. Some npm registries (for example, npmE) might support alternative auth strategies besides classic username/password entry in legacy npm.
         auth_type: Option<String>,

--- a/src/command.rs
+++ b/src/command.rs
@@ -152,9 +152,11 @@ fn login(
     always_auth: bool,
     auth_type: Option<String>,
 ) -> result::Result<(), Error> {
-    npm::npm_login(registry, scope, always_auth, auth_type)?;
+    let registry = registry.unwrap_or(npm::DEFAULT_NPM_REGISTRY.to_string());
 
-    PBAR.message("👋  logged you in!");
+    npm::npm_login(&registry, &scope, always_auth, &auth_type)?;
+
+    PBAR.message(&format!("👋  logged you in to {}!", registry));
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -25,15 +25,15 @@ pub enum Command {
     },
 
     #[structopt(name = "pack")]
-    /// 🍱  create a tar of your npm package but don't publish! [NOT IMPLEMENTED]
+    /// 🍱  create a tar of your npm package but don't publish!
     Pack { path: Option<String> },
 
     #[structopt(name = "publish")]
-    /// 🎆  pack up your npm package and publish! [NOT IMPLEMENTED]
+    /// 🎆  pack up your npm package and publish!
     Publish { path: Option<String> },
 
     #[structopt(name = "login", alias = "adduser", alias = "add-user")]
-    /// 👤  Add a registry user account! (aliases: adduser, add-user) [NOT IMPLEMENTED]
+    /// 👤  Add a registry user account! (aliases: adduser, add-user)
     Login {
         #[structopt(long = "registry", short = "r")]
         /// Default: 'https://registry.npmjs.org/'.

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -28,3 +28,40 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
         Ok(())
     }
 }
+
+pub fn npm_adduser(
+    registry: Option<String>,
+    scope: Option<String>,
+    always_auth: bool,
+    auth_type: Option<String>,
+) -> Result<(), Error> {
+    let status = Command::new("npm")
+        .arg("adduser")
+        .arg(if let Some(registry) = registry {
+            format!("--registry {}", registry)
+        } else {
+            String::from("")
+        })
+        .arg(if let Some(scope) = scope {
+            format!("--scope {}", scope)
+        } else {
+            String::from("")
+        })
+        .arg(if always_auth == true {
+            String::from("--always_auth")
+        } else {
+            String::from("")
+        })
+        .arg(if let Some(auth_type) = auth_type {
+            format!("--auth_type {}", auth_type)
+        } else {
+            String::from("")
+        })
+        .status()?;
+
+    if !status.success() {
+        bail!("Adding registry user account failed");
+    } else {
+        Ok(())
+    }
+}

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -35,29 +35,24 @@ pub fn npm_adduser(
     always_auth: bool,
     auth_type: Option<String>,
 ) -> Result<(), Error> {
-    let status = Command::new("npm")
-        .arg("adduser")
-        .arg(if let Some(registry) = registry {
-            format!("--registry {}", registry)
-        } else {
-            String::from("")
-        })
-        .arg(if let Some(scope) = scope {
-            format!("--scope {}", scope)
-        } else {
-            String::from("")
-        })
-        .arg(if always_auth == true {
-            String::from("--always_auth")
-        } else {
-            String::from("")
-        })
-        .arg(if let Some(auth_type) = auth_type {
-            format!("--auth_type {}", auth_type)
-        } else {
-            String::from("")
-        })
-        .status()?;
+    let mut args = String::new();
+
+    if let Some(registry) = registry {
+        args.push_str(&format!(" --registry={}", registry))
+    }
+    if let Some(scope) = scope {
+        args.push_str(&format!(" --scope={}", scope))
+    }
+
+    if always_auth == true {
+        args.push_str(" --always_auth")
+    }
+
+    if let Some(auth_type) = auth_type {
+        args.push_str(&format!(" --auth_type={}", auth_type))
+    }
+
+    let status = Command::new("npm").arg("adduser").arg(args).status()?;
 
     if !status.success() {
         bail!("Adding registry user account failed");

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -29,7 +29,7 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
     }
 }
 
-pub fn npm_adduser(
+pub fn npm_login(
     registry: Option<String>,
     scope: Option<String>,
     always_auth: bool,
@@ -52,10 +52,10 @@ pub fn npm_adduser(
         args.push_str(&format!(" --auth_type={}", auth_type))
     }
 
-    let status = Command::new("npm").arg("adduser").arg(args).status()?;
+    let status = Command::new("npm").arg("login").arg(args).status()?;
 
     if !status.success() {
-        bail!("Adding registry user account failed");
+        bail!("Registry user account login failed");
     } else {
         Ok(())
     }

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,6 +1,8 @@
 use error::Error;
 use std::process::{Command, Stdio};
 
+pub const DEFAULT_NPM_REGISTRY: &'static str = "https://registry.npmjs.org/";
+
 pub fn npm_pack(path: &str) -> Result<(), Error> {
     let pkg_file_path = format!("{}/pkg", path);
     let output = Command::new("npm")
@@ -30,16 +32,15 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
 }
 
 pub fn npm_login(
-    registry: Option<String>,
-    scope: Option<String>,
+    registry: &String,
+    scope: &Option<String>,
     always_auth: bool,
-    auth_type: Option<String>,
+    auth_type: &Option<String>,
 ) -> Result<(), Error> {
     let mut args = String::new();
 
-    if let Some(registry) = registry {
-        args.push_str(&format!(" --registry={}", registry));
-    }
+    args.push_str(&format!("--registry={}", registry));
+
     if let Some(scope) = scope {
         args.push_str(&format!(" --scope={}", scope));
     }
@@ -61,7 +62,7 @@ pub fn npm_login(
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Registry user account login failed", s)
+        Error::cli(&format!("Login to registry {} failed", registry), s)
     } else {
         Ok(())
     }


### PR DESCRIPTION
Implements #83 

This wraps npm adduser. I’ve copied the argument descriptions from npm.
By the way: why are all sub commands marked as NOT IMPLEMENTED?

I’m a little unsure about some of the solutions I used here.

1. `if let` inside `arg()` seems wired.
2. passing 4 args down multiple times feels strange

I took the liberty to add some spacing inside the command enum, since it really confused me for a few minutes.

Does this seem okay otherwise?

Cheers!


Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
````
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
