### PR TITLE
feat(command): expose --no-typescript option to init command

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -29,7 +29,7 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     }
 }
 
-pub fn wasm_bindgen_build(path: &str, name: &str) -> Result<(), Error> {
+pub fn wasm_bindgen_build(path: &str, name: &str, disable_dts: bool) -> Result<(), Error> {
     let step = format!(
         "{} {}Running WASM-bindgen...",
         style("[7/7]").bold().dim(),
@@ -38,11 +38,18 @@ pub fn wasm_bindgen_build(path: &str, name: &str) -> Result<(), Error> {
     let pb = PBAR.message(&step);
     let binary_name = name.replace("-", "_");
     let wasm_path = format!("target/wasm32-unknown-unknown/release/{}.wasm", binary_name);
+    let dts_arg = if disable_dts == false {
+        "--typescript"
+    } else {
+        "--no-typescript"
+    };
+
     let output = Command::new("wasm-bindgen")
         .current_dir(path)
         .arg(&wasm_path)
         .arg("--out-dir")
         .arg("./pkg")
+        .arg(dts_arg)
         .output()?;
     pb.finish();
     if !output.status.success() {

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,6 +22,8 @@ pub enum Command {
         path: Option<String>,
         #[structopt(long = "scope", short = "s")]
         scope: Option<String>,
+        #[structopt(long = "no-typescript")]
+        disable_dts: bool,
     },
     #[structopt(name = "pack")]
     /// 🍱  create a tar of your npm package but don't publish! [NOT IMPLEMENTED]
@@ -35,7 +37,11 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
     // Run the correct command based off input and store the result of it so that we can clear
     // the progress bar then return it
     let status = match command {
-        Command::Init { path, scope } => init(path, scope),
+        Command::Init {
+            path,
+            scope,
+            disable_dts,
+        } => init(path, scope, disable_dts),
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
     };
@@ -65,7 +71,11 @@ pub fn create_pkg_dir(path: &str) -> result::Result<(), Error> {
     Ok(())
 }
 
-fn init(path: Option<String>, scope: Option<String>) -> result::Result<(), Error> {
+fn init(
+    path: Option<String>,
+    scope: Option<String>,
+    disable_dts: bool,
+) -> result::Result<(), Error> {
     let started = Instant::now();
 
     let crate_path = set_crate_path(path);
@@ -73,11 +83,11 @@ fn init(path: Option<String>, scope: Option<String>) -> result::Result<(), Error
     build::rustup_add_wasm_target()?;
     build::cargo_build_wasm(&crate_path)?;
     create_pkg_dir(&crate_path)?;
-    manifest::write_package_json(&crate_path, scope)?;
+    manifest::write_package_json(&crate_path, scope, disable_dts)?;
     readme::copy_from_crate(&crate_path)?;
     bindgen::cargo_install_wasm_bindgen()?;
     let name = manifest::get_crate_name(&crate_path)?;
-    bindgen::wasm_bindgen_build(&crate_path, &name)?;
+    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts)?;
     PBAR.message(&format!(
         "{} Done in {}",
         emoji::SPARKLE,

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -29,7 +29,7 @@ fn it_gets_the_crate_name_provided_path() {
 fn it_creates_a_package_json_default_path() {
     let path = ".".to_string();
     wasm_pack::command::create_pkg_dir(&path).unwrap();
-    assert!(manifest::write_package_json(&path, None).is_ok());
+    assert!(manifest::write_package_json(&path, None, false).is_ok());
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
@@ -42,13 +42,15 @@ fn it_creates_a_package_json_default_path() {
     );
     assert_eq!(pkg.files, ["wasm_pack_bg.wasm"]);
     assert_eq!(pkg.main, "wasm_pack.js");
+    let types = pkg.types.unwrap_or_default();
+    assert_eq!(types, "wasm_pack.d.ts");
 }
 
 #[test]
 fn it_creates_a_package_json_provided_path() {
     let path = "tests/fixtures/js-hello-world".to_string();
     wasm_pack::command::create_pkg_dir(&path).unwrap();
-    assert!(manifest::write_package_json(&path, None).is_ok());
+    assert!(manifest::write_package_json(&path, None, false).is_ok());
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
@@ -60,7 +62,7 @@ fn it_creates_a_package_json_provided_path() {
 fn it_creates_a_package_json_provided_path_with_scope() {
     let path = "tests/fixtures/scopes".to_string();
     wasm_pack::command::create_pkg_dir(&path).unwrap();
-    assert!(manifest::write_package_json(&path, Some("test".to_string())).is_ok());
+    assert!(manifest::write_package_json(&path, Some("test".to_string()), false).is_ok());
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());

--- a/tests/manifest/utils.rs
+++ b/tests/manifest/utils.rs
@@ -13,6 +13,7 @@ pub struct NpmPackage {
     pub repository: Repository,
     pub files: Vec<String>,
     pub main: String,
+    pub types: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- relates to #107 

I got so excited about #107 as typescript user so gave a quick stab, but not sure if this change is intended scope for issue itself. Feel freely close / or suggest as needed. 🙏 

This PR intends to ask bindgen to generate typescript definition as well, also expand `NpmPackage` struct to include `types` property into `package.json`. It currently takes naïve approach by specifying type definition to same entrypoint of `main`.

Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
