### PR TITLE
feat(error_msg): Make custom module for errors

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,6 +1,6 @@
 use console::style;
 use emoji;
-use failure::Error;
+use error::Error;
 use std::process::Command;
 use PBAR;
 
@@ -22,8 +22,7 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
             PBAR.info("wasm-bindgen already installed");
             return Ok(());
         }
-        PBAR.error("Installing wasm-bindgen failed");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("Installing wasm-bindgen failed", s)
     } else {
         Ok(())
     }
@@ -47,8 +46,7 @@ pub fn wasm_bindgen_build(path: &str, name: &str) -> Result<(), Error> {
     pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        PBAR.error("wasm-bindgen failed to execute properly");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("wasm-bindgen failed to execute properly", s)
     } else {
         Ok(())
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,6 @@
 use console::style;
 use emoji;
-use failure::Error;
+use error::Error;
 use std::process::Command;
 use PBAR;
 
@@ -19,8 +19,7 @@ pub fn rustup_add_wasm_target() -> Result<(), Error> {
     pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        PBAR.error("Adding the wasm32-unknown-unknown target failed");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("Adding the wasm32-unknown-unknown target failed", s)
     } else {
         Ok(())
     }
@@ -43,8 +42,7 @@ pub fn cargo_build_wasm(path: &str) -> Result<(), Error> {
     pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        PBAR.error("Compilation of your program failed");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("Compilation of your program failed", s)
     } else {
         Ok(())
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,7 @@ use bindgen;
 use build;
 use console::style;
 use emoji;
-use failure::Error;
+use error::Error;
 use indicatif::HumanDuration;
 use manifest;
 use npm;
@@ -39,6 +39,13 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
     };
+
+    match status {
+        Ok(_) => {}
+        Err(ref e) => {
+            PBAR.error(e.error_type());
+        }
+    }
 
     // Make sure we always clear the progress bar before we abort the program otherwise
     // stderr and stdout output get eaten up and nothing will work. If this part fails

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,57 @@
+//! Code related to error handling for wasm-pack
+use serde_json;
+use std::borrow::Cow;
+use std::io;
+use toml;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    /// Maps any underlying I/O errors that are thrown to this variant
+    #[fail(display = "{}", _0)]
+    Io(#[cause] io::Error),
+    #[fail(display = "{}", _0)]
+    SerdeJson(#[cause] serde_json::Error),
+    #[fail(display = "{}", _0)]
+    SerdeToml(#[cause] toml::de::Error),
+    #[fail(display = "{}. stderr:\n\n{}", message, stderr)]
+    Cli { message: String, stderr: String },
+}
+
+impl Error {
+    pub fn cli(message: &str, stderr: Cow<str>) -> Result<(), Self> {
+        Err(Error::Cli {
+            message: message.to_string(),
+            stderr: stderr.to_string(),
+        })
+    }
+
+    pub fn error_type(&self) -> String {
+        match self {
+            Error::Io(_) => "There was an I/O error. Details:\n\n",
+            Error::SerdeJson(_) => "There was an JSON error. Details:\n\n",
+            Error::SerdeToml(_) => "There was an TOML error. Details:\n\n",
+            Error::Cli {
+                message: _,
+                stderr: _,
+            } => "There was an error while calling another CLI tool. Details:\n\n",
+        }.to_string()
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error::SerdeJson(e)
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(e: toml::de::Error) -> Self {
+        Error::SerdeToml(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bindgen;
 pub mod build;
 pub mod command;
 pub mod emoji;
+pub mod error;
 pub mod manifest;
 pub mod npm;
 pub mod progressbar;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,7 +3,7 @@ use std::io::prelude::*;
 
 use console::style;
 use emoji;
-use failure::Error;
+use error::Error;
 use serde_json;
 use toml;
 use PBAR;

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,6 +1,5 @@
-use failure::Error;
+use error::Error;
 use std::process::Command;
-use PBAR;
 
 pub fn npm_pack(path: &str) -> Result<(), Error> {
     let pkg_file_path = format!("{}/pkg", path);
@@ -10,8 +9,7 @@ pub fn npm_pack(path: &str) -> Result<(), Error> {
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        PBAR.error("Packaging up your code failed");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("Packaging up your code failed", s)
     } else {
         Ok(())
     }
@@ -25,8 +23,7 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        PBAR.error("Publishing to npm failed");
-        bail!(format!("Details:\n{}", s));
+        Error::cli("Publishing to npm failed", s)
     } else {
         Ok(())
     }

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -1,6 +1,6 @@
 use console::style;
 use emoji;
-use failure::Error;
+use error::Error;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 pub struct ProgressOutput {
@@ -40,7 +40,7 @@ impl ProgressOutput {
         bar.finish();
     }
 
-    pub fn error(&self, message: &str) {
+    pub fn error(&self, message: String) {
         let err = format!(
             "{} {}: {}",
             emoji::ERROR,

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,5 +1,5 @@
 use console::style;
-use failure::Error;
+use error::Error;
 use std::fs;
 
 use emoji;


### PR DESCRIPTION
This does two big things:

- We add custom error messages and conversions from other error types
  into our own error type. This means we can create or modify more
  fine grained errors rather than using whatever `failure::Error` gives
  us. The first one we have is a `Cli` error, whereby calls to things
  like wasm-bindgen or npm failed.
- We also make it so that `PBAR.error()` is called only on exit. We grab
  a reference to whatever error gets passed up the chain, have it
  generate a message to be printed as an error to PBAR, close up PBAR
  like normal, and then print our actual error message to stderr!

The main benefits of this is that as long as we return an error, PBAR
will print and close itself up and we don't need to call it every time
or forget that we would need to call it, and we put error details
specifically into our error!

Closes #12

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
