### PR TITLE
Removed 'NOT IMPLEMENTED' flags from commands that are now implemented.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -17,17 +17,17 @@ use PBAR;
 #[derive(Debug, StructOpt)]
 pub enum Command {
     #[structopt(name = "init")]
-    /// 🐣  initialize a package.json based on your compiled wasm
+    /// 🐣  initialize a package.json based on your compiled wasm!
     Init {
         path: Option<String>,
         #[structopt(long = "scope", short = "s")]
         scope: Option<String>,
     },
     #[structopt(name = "pack")]
-    /// 🍱  create a tar of your npm package but don't publish! [NOT IMPLEMENTED]
+    /// 🍱  create a tar of your npm package but don't publish!
     Pack { path: Option<String> },
     #[structopt(name = "publish")]
-    /// 🎆  pack up your npm package and publish! [NOT IMPLEMENTED]
+    /// 🎆  pack up your npm package and publish!
     Publish { path: Option<String> },
 }
 


### PR DESCRIPTION
I noticed this while working on a different issue, and figured I would open a quick PR about it :) Currently, the output generated by running `wasm-pack --help` looks like this:

```
✨  wasm-pack --help
wasm-pack 0.2.0
Ashley Williams <ashley666ashley@gmail.com>
📦 ✨  pack and publish your wasm!

USAGE:
    wasm-pack [FLAGS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    log all the things

SUBCOMMANDS:
    help       Prints this message or the help of the given subcommand(s)
    init       🐣  initialize a package.json based on your compiled wasm
    pack       🍱  create a tar of your npm package but don't publish! [NOT IMPLEMENTED]
    publish    🎆  pack up your npm package and publish! [NOT IMPLEMENTED]
```

This commit removes the "[NOT IMPLEMENTED]" notices from the `pack` and `publish` subcommands' descriptions. I added an exclamation mark to the end of the `init` subcommand description for consistency, and because initializing a `package.json` is exciting too :)

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
