### PR TITLE
Add a --target option target different environment (nodejs, browser)

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -32,7 +32,7 @@ pub fn wasm_bindgen_build(
     path: &str,
     name: &str,
     disable_dts: bool,
-    nodejs: bool,
+    target: String,
 ) -> Result<(), Error> {
     let step = format!(
         "{} {}Running WASM-bindgen...",
@@ -49,7 +49,10 @@ pub fn wasm_bindgen_build(
         "--no-typescript"
     };
 
-    let nodejs_arg = if nodejs { "--nodejs" } else { "" };
+    let target_arg = match target.as_str() {
+        "nodejs" => "--nodejs",
+        _ => "--browser",
+    };
 
     let output = Command::new("wasm-bindgen")
         .current_dir(path)
@@ -57,7 +60,7 @@ pub fn wasm_bindgen_build(
         .arg("--out-dir")
         .arg("./pkg")
         .arg(dts_arg)
-        .arg(nodejs_arg)
+        .arg(target_arg)
         .output()?;
     pb.finish();
     if !output.status.success() {

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -28,7 +28,12 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
     }
 }
 
-pub fn wasm_bindgen_build(path: &str, name: &str, disable_dts: bool) -> Result<(), Error> {
+pub fn wasm_bindgen_build(
+    path: &str,
+    name: &str,
+    disable_dts: bool,
+    nodejs: bool,
+) -> Result<(), Error> {
     let step = format!(
         "{} {}Running WASM-bindgen...",
         style("[7/7]").bold().dim(),
@@ -37,11 +42,14 @@ pub fn wasm_bindgen_build(path: &str, name: &str, disable_dts: bool) -> Result<(
     let pb = PBAR.message(&step);
     let binary_name = name.replace("-", "_");
     let wasm_path = format!("target/wasm32-unknown-unknown/release/{}.wasm", binary_name);
+
     let dts_arg = if disable_dts == false {
         "--typescript"
     } else {
         "--no-typescript"
     };
+
+    let nodejs_arg = if nodejs { "--nodejs" } else { "" };
 
     let output = Command::new("wasm-bindgen")
         .current_dir(path)
@@ -49,6 +57,7 @@ pub fn wasm_bindgen_build(path: &str, name: &str, disable_dts: bool) -> Result<(
         .arg("--out-dir")
         .arg("./pkg")
         .arg(dts_arg)
+        .arg(nodejs_arg)
         .output()?;
     pb.finish();
     if !output.status.success() {

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,10 +20,20 @@ pub enum Command {
     /// 🐣  initialize a package.json based on your compiled wasm!
     Init {
         path: Option<String>,
+
         #[structopt(long = "scope", short = "s")]
         scope: Option<String>,
+
         #[structopt(long = "no-typescript")]
+        /// By default a *.d.ts file is generated for the generated JS file, but
+        /// this flag will disable generating this TypeScript file.
         disable_dts: bool,
+
+        #[structopt(long = "nodejs")]
+        /// This flag will tailor output for Node instead of browsers, allowing
+        /// for native usage of require of the generated JS and internally using
+        /// require instead of ES modules. 
+        nodejs: bool,
     },
 
     #[structopt(name = "pack")]
@@ -39,22 +49,30 @@ pub enum Command {
     Login {
         #[structopt(long = "registry", short = "r")]
         /// Default: 'https://registry.npmjs.org/'.
-        /// The base URL of the npm package registry. If scope is also specified, this registry will only be used for packages with that scope. scope defaults to the scope of the project directory you're currently in, if any.
+        /// The base URL of the npm package registry. If scope is also
+        /// specified, this registry will only be used for packages with that
+        /// scope. scope defaults to the scope of the project directory you're
+        /// currently in, if any.
         registry: Option<String>,
 
         #[structopt(long = "scope", short = "s")]
         /// Default: none.
-        /// If specified, the user and login credentials given will be associated with the specified scope.
+        /// If specified, the user and login credentials given will be
+        /// associated with the specified scope.
         scope: Option<String>,
 
         #[structopt(long = "always-auth", short = "a")]
-        /// If specified, save configuration indicating that all requests to the given registry should include authorization information. Useful for private registries. Can be used with --registry and / or --scope
+        /// If specified, save configuration indicating that all requests to the
+        /// given registry should include authorization information. Useful for
+        /// private registries. Can be used with --registry and / or --scope
         always_auth: bool,
 
         #[structopt(long = "auth-type", short = "t")]
         /// Default: 'legacy'.
         /// Type: 'legacy', 'sso', 'saml', 'oauth'.
-        /// What authentication strategy to use with adduser/login. Some npm registries (for example, npmE) might support alternative auth strategies besides classic username/password entry in legacy npm.
+        /// What authentication strategy to use with adduser/login. Some npm
+        /// registries (for example, npmE) might support alternative auth
+        /// strategies besides classic username/password entry in legacy npm.
         auth_type: Option<String>,
     },
 }
@@ -67,7 +85,8 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
             path,
             scope,
             disable_dts,
-        } => init(path, scope, disable_dts),
+            nodejs,
+        } => init(path, scope, disable_dts, nodejs),
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
         Command::Login {
@@ -114,6 +133,7 @@ fn init(
     path: Option<String>,
     scope: Option<String>,
     disable_dts: bool,
+    nodejs: bool,
 ) -> result::Result<(), Error> {
     let started = Instant::now();
 
@@ -126,7 +146,7 @@ fn init(
     readme::copy_from_crate(&crate_path)?;
     bindgen::cargo_install_wasm_bindgen()?;
     let name = manifest::get_crate_name(&crate_path)?;
-    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts)?;
+    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts, nodejs)?;
     PBAR.message(&format!(
         "{} Done in {}",
         emoji::SPARKLE,

--- a/src/command.rs
+++ b/src/command.rs
@@ -29,11 +29,9 @@ pub enum Command {
         /// this flag will disable generating this TypeScript file.
         disable_dts: bool,
 
-        #[structopt(long = "nodejs")]
-        /// This flag will tailor output for Node instead of browsers, allowing
-        /// for native usage of require of the generated JS and internally using
-        /// require instead of ES modules. 
-        nodejs: bool,
+        #[structopt(long = "target", short = "t", default_value = "browser")]
+        /// Sets the target environment. [possible values: browser, nodejs]
+        target: String,
     },
 
     #[structopt(name = "pack")]
@@ -85,8 +83,8 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
             path,
             scope,
             disable_dts,
-            nodejs,
-        } => init(path, scope, disable_dts, nodejs),
+            target,
+        } => init(path, scope, disable_dts, target),
         Command::Pack { path } => pack(path),
         Command::Publish { path } => publish(path),
         Command::Login {
@@ -133,7 +131,7 @@ fn init(
     path: Option<String>,
     scope: Option<String>,
     disable_dts: bool,
-    nodejs: bool,
+    target: String,
 ) -> result::Result<(), Error> {
     let started = Instant::now();
 
@@ -146,7 +144,7 @@ fn init(
     readme::copy_from_crate(&crate_path)?;
     bindgen::cargo_install_wasm_bindgen()?;
     let name = manifest::get_crate_name(&crate_path)?;
-    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts, nodejs)?;
+    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts, target)?;
     PBAR.message(&format!(
         "{} Done in {}",
         emoji::SPARKLE,


### PR DESCRIPTION
Implements #75 

I had some time in the train – I hope it's okay.
Some lines of documentation and a few line breaks for readability included.

Thoughts?

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
