### PR TITLE
Add a --debug option to suppress cargo build --release.

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -54,5 +54,7 @@ output package using cargo's
 this way is faster but applies few optimizations to the output, and enables
 debug assertions and other runtime correctness checks.
 
+The exact meaning of this flag may evolve as the platform matures.
+
 [npm-scope-documentation]: https://docs.npmjs.com/misc/scope
 [cargo-profile-sections-documentation]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections

--- a/docs/init.md
+++ b/docs/init.md
@@ -46,4 +46,13 @@ This command would create a `package.json` file for a package called
 `@test/js-hello-world`. For more information about scoping, you can refer to
 the npm documentation [here][npm-scope-documentation].
 
+## Debug
+
+The init command accepts an optional `--debug` argument. This will build the
+output package using cargo's
+[default non-release profile][cargo-profile-sections-documentation]. Building
+this way is faster but applies few optimizations to the output, and enables
+debug assertions and other runtime correctness checks.
+
 [npm-scope-documentation]: https://docs.npmjs.com/misc/scope
+[cargo-profile-sections-documentation]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -34,6 +34,7 @@ pub fn wasm_bindgen_build(
     name: &str,
     disable_dts: bool,
     target: String,
+    debug: bool,
 ) -> Result<(), Error> {
     let step = format!(
         "{} {}Running WASM-bindgen...",
@@ -42,8 +43,11 @@ pub fn wasm_bindgen_build(
     );
     let pb = PBAR.message(&step);
     let binary_name = name.replace("-", "_");
-    let wasm_path = format!("target/wasm32-unknown-unknown/release/{}.wasm", binary_name);
-
+    let release_or_debug = if debug { "debug" } else { "release" };
+    let wasm_path = format!(
+        "target/wasm32-unknown-unknown/{}/{}.wasm",
+        release_or_debug, binary_name
+    );
     let dts_arg = if disable_dts == false {
         "--typescript"
     } else {

--- a/src/build.rs
+++ b/src/build.rs
@@ -25,20 +25,22 @@ pub fn rustup_add_wasm_target() -> Result<(), Error> {
     }
 }
 
-pub fn cargo_build_wasm(path: &str) -> Result<(), Error> {
+pub fn cargo_build_wasm(path: &str, debug: bool) -> Result<(), Error> {
     let step = format!(
         "{} {}Compiling to WASM...",
         style("[2/7]").bold().dim(),
         emoji::CYCLONE
     );
     let pb = PBAR.message(&step);
-    let output = Command::new("cargo")
-        .current_dir(path)
-        .arg("build")
-        .arg("--release")
-        .arg("--target")
-        .arg("wasm32-unknown-unknown")
-        .output()?;
+    let output = {
+        let mut cmd = Command::new("cargo");
+        cmd.current_dir(path).arg("build");
+        if !debug {
+            cmd.arg("--release");
+        }
+        cmd.arg("--target").arg("wasm32-unknown-unknown");
+        cmd.output()?
+    };
     pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);

--- a/src/command.rs
+++ b/src/command.rs
@@ -32,6 +32,10 @@ pub enum Command {
         #[structopt(long = "target", short = "t", default_value = "browser")]
         /// Sets the target environment. [possible values: browser, nodejs]
         target: String,
+
+        #[structopt(long = "debug")]
+        /// Build without --release.
+        debug: bool,
     },
 
     #[structopt(name = "pack")]
@@ -84,17 +88,19 @@ pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), Error
             scope,
             disable_dts,
             target,
+            debug,
         } => {
             info!(&log, "Running init command...");
             info!(
                 &log,
-                "Path: {:?}, Scope: {:?}, Disable Dts: {}, Target: {}",
+                "Path: {:?}, Scope: {:?}, Disable Dts: {}, Target: {}, Debug: {}",
                 &path,
                 &scope,
                 &disable_dts,
-                &target
+                &target,
+                debug
             );
-            init(path, scope, disable_dts, target, &log)
+            init(path, scope, disable_dts, target, &log, debug)
         }
         Command::Pack { path } => {
             info!(&log, "Running pack command...");
@@ -164,6 +170,7 @@ fn init(
     disable_dts: bool,
     target: String,
     log: &Logger,
+    debug: bool,
 ) -> result::Result<(), Error> {
     let started = Instant::now();
 
@@ -174,7 +181,7 @@ fn init(
     info!(&log, "Adding wasm-target was successful.");
 
     info!(&log, "Building wasm...");
-    build::cargo_build_wasm(&crate_path)?;
+    build::cargo_build_wasm(&crate_path, debug)?;
 
     #[cfg(not(target_os = "windows"))]
     info!(
@@ -229,7 +236,7 @@ fn init(
     );
 
     info!(&log, "Building the wasm bindings...");
-    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts, target)?;
+    bindgen::wasm_bindgen_build(&crate_path, &name, disable_dts, target, debug)?;
     #[cfg(not(target_os = "windows"))]
     info!(&log, "wasm bindings were built at {}/pkg.", &crate_path);
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
First pass at #126 .

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
