### PR TITLE
Update Travis' rustfmt arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     script:
     - cargo test --locked
     - rustup component add rustfmt-preview
-    - cargo fmt -- --write-mode diff
+    - cargo fmt --all -- --check
     env: RUST_BACKTRACE=1
 
   # dist linux binary


### PR DESCRIPTION
No issue existing currently, but surfaced in #125 and #127.
Travis builds are failing caused by an update in rustfmt.
The command is now according to: https://github.com/rust-lang-nursery/rustfmt#checking-style-on-a-ci-server

Let's see if it works 🤔 

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
