### PR TITLE
feat(fix ci): Update failing rustfmt command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     script:
     - cargo test --locked
     - rustup component add rustfmt-preview
-    - cargo fmt -- --write-mode diff
+    - cargo fmt -- --check
     env: RUST_BACKTRACE=1
 
   # dist linux binary


### PR DESCRIPTION
CI was broken due to a change in flags for how rustfmt works. This
changes the CI build to use the one we want which is to check if there
is a broken diff or not.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
