### PR TITLE
Add the TypeScript definition to the published files

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -66,6 +66,15 @@ impl CargoManifest {
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
         }
+        let mut files = vec![wasm_file];
+
+        match dts_file {
+            Some(ref dts_file) => {
+                files.push(dts_file.to_string());
+            }
+            None => {}
+        }
+
         NpmPackage {
             name: self.package.name,
             collaborators: self.package.authors,
@@ -76,7 +85,7 @@ impl CargoManifest {
                 ty: "git".to_string(),
                 url: repo_url,
             }),
-            files: vec![wasm_file],
+            files: files,
             main: js_file,
             types: dts_file,
         }

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -40,7 +40,7 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm"]);
+    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]);
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨


Fixes #137