### PR TITLE
check that crate type includes cdylib

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -211,6 +211,19 @@ fn init(
     #[cfg(target_os = "windows")]
     info!(&log, "Copied readme from crate to {}\\pkg.", &crate_path);
 
+    info!(&log, "Checking the crate type from the manifest...");
+    manifest::check_crate_type(&crate_path)?;
+    #[cfg(not(target_os = "windows"))]
+    info!(
+        &log,
+        "Checked crate type from the manifest at {}/Cargo.toml.", &crate_path
+    );
+    #[cfg(target_os = "windows")]
+    info!(
+        &log,
+        "Checked crate type from the manifest at {}\\Cargo.toml.", &crate_path
+    );
+
     info!(&log, "Installing wasm-bindgen-cli...");
     bindgen::cargo_install_wasm_bindgen()?;
     info!(&log, "Installing wasm-bindgen-cli was successful.");

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[fail(display = "{}. stderr:\n\n{}", message, stderr)]
     Cli { message: String, stderr: String },
     #[fail(display = "{}", message)]
-    Config { message: String },
+    CrateConfig { message: String },
 }
 
 impl Error {
@@ -27,8 +27,8 @@ impl Error {
         })
     }
 
-    pub fn config(message: &str) -> Result<(), Self> {
-        Err(Error::Config {
+    pub fn crate_config(message: &str) -> Result<(), Self> {
+        Err(Error::CrateConfig {
             message: message.to_string(),
         })
     }
@@ -42,7 +42,9 @@ impl Error {
                 message: _,
                 stderr: _,
             } => "There was an error while calling another CLI tool. Details:\n\n",
-            Error::Config { message: _ } => "There was a configuration error. Details:\n\n",
+            Error::CrateConfig { message: _ } => {
+                "There was a crate configuration error. Details:\n\n"
+            }
         }.to_string()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     SerdeToml(#[cause] toml::de::Error),
     #[fail(display = "{}. stderr:\n\n{}", message, stderr)]
     Cli { message: String, stderr: String },
+    #[fail(display = "{}", message)]
+    Config { message: String },
 }
 
 impl Error {
@@ -22,6 +24,12 @@ impl Error {
         Err(Error::Cli {
             message: message.to_string(),
             stderr: stderr.to_string(),
+        })
+    }
+
+    pub fn config(message: &str) -> Result<(), Self> {
+        Err(Error::Config {
+            message: message.to_string(),
         })
     }
 
@@ -34,6 +42,7 @@ impl Error {
                 message: _,
                 stderr: _,
             } => "There was an error while calling another CLI tool. Details:\n\n",
+            Error::Config { message: _ } => "There was a configuration error. Details:\n\n",
         }.to_string()
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -153,7 +153,9 @@ fn has_cdylib(path: &str) -> Result<bool, Error> {
 
 pub fn check_crate_type(path: &str) -> Result<(), Error> {
     if !has_cdylib(path)? {
-        Error::config("crate-type must include cdylib to compile to wasm32-unknown-unknown")
+        Error::crate_config(
+            "crate-type must include cdylib to compile to wasm32-unknown-unknown. Add the following to your Cargo.toml file:\n\n[lib]\ncrate-type = [\"cdylib\"]"
+        )
     } else {
         Ok(())
     }

--- a/tests/fixtures/bad-cargo-toml/Cargo.toml
+++ b/tests/fixtures/bad-cargo-toml/Cargo.toml
@@ -3,5 +3,8 @@ name = "bad-cargo-toml"
 version = "0.1.0"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 
+[lib]
+crate-type = ["foo"]
+
 [dependencies]
 wasm-bindgen = "0.2"

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -26,6 +26,21 @@ fn it_gets_the_crate_name_provided_path() {
 }
 
 #[test]
+fn it_checks_has_cdylib_default_path() {
+    assert!(manifest::check_crate_type(".").is_err());
+}
+
+#[test]
+fn it_checks_has_cdylib_provided_path() {
+    assert!(manifest::check_crate_type("tests/fixtures/js-hello-world").is_ok());
+}
+
+#[test]
+fn it_checks_has_cdylib_wrong_crate_type() {
+    assert!(manifest::check_crate_type("tests/fixtures/bad-cargo-toml").is_err());
+}
+
+#[test]
 fn it_creates_a_package_json_default_path() {
     let path = ".".to_string();
     wasm_pack::command::create_pkg_dir(&path).unwrap();


### PR DESCRIPTION
Checks that crate-type includes "cdylib" -- fails with an error if it does not.

Closes https://github.com/ashleygwilliams/wasm-pack/issues/140

thank you for holding the rust workshop at jsconf this past weekend @ashleygwilliams! 😄  
