### PR TITLE
feat(wasm_bindgen): checks wasm-bindgen declaration in Cargo.toml

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -169,6 +169,10 @@ fn init(
 
     let crate_path = set_crate_path(path);
 
+    info!(&log, "Checking wasm-bindgen dependency...");
+    manifest::check_wasm_bindgen(&crate_path)?;
+    info!(&log, "wasm-bindgen dependency is correctly declared.");
+
     info!(&log, "Adding wasm-target...");
     build::rustup_add_wasm_target()?;
     info!(&log, "Adding wasm-target was successful.");

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     SerdeToml(#[cause] toml::de::Error),
     #[fail(display = "{}. stderr:\n\n{}", message, stderr)]
     Cli { message: String, stderr: String },
+    #[fail(display = "{}", message)]
+    CrateConfig { message: String },
 }
 
 impl Error {
@@ -22,6 +24,12 @@ impl Error {
         Err(Error::Cli {
             message: message.to_string(),
             stderr: stderr.to_string(),
+        })
+    }
+
+    pub fn crate_config(message: &str) -> Result<(), Self> {
+        Err(Error::CrateConfig {
+            message: message.to_string(),
         })
     }
 
@@ -34,6 +42,9 @@ impl Error {
                 message: _,
                 stderr: _,
             } => "There was an error while calling another CLI tool. Details:\n\n",
+            Error::CrateConfig { message: _ } => {
+                "There was a crate configuration error. Details:\n\n"
+            }
         }.to_string()
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -11,6 +11,7 @@ use PBAR;
 #[derive(Deserialize)]
 struct CargoManifest {
     package: CargoPackage,
+    dependencies: Option<CargoDependencies>,
 }
 
 #[derive(Deserialize)]
@@ -21,6 +22,12 @@ struct CargoPackage {
     version: String,
     license: Option<String>,
     repository: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CargoDependencies {
+    #[serde(rename = "wasm-bindgen")]
+    wasm_bindgen: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -135,4 +142,16 @@ pub fn write_package_json(
 
 pub fn get_crate_name(path: &str) -> Result<String, Error> {
     Ok(read_cargo_toml(path)?.package.name)
+}
+
+pub fn check_wasm_bindgen(path: &str) -> Result<(), Error> {
+    if read_cargo_toml(path)?.dependencies.map_or(false, |x| {
+        !x.wasm_bindgen.unwrap_or("".to_string()).is_empty()
+    }) {
+        return Ok(());
+    }
+    Error::crate_config(&format!(
+        "Ensure that you have \"{}\" as a dependency in your Cargo.toml file:\n[dependencies]\nwasm-bindgen = \"0.2\"",
+        style("wasm-bindgen").bold().dim()
+    ))
 }

--- a/tests/fixtures/bad-cargo-toml/Cargo.toml
+++ b/tests/fixtures/bad-cargo-toml/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 
 [dependencies]
-wasm-bindgen = "0.2"

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -69,3 +69,13 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
 }
+
+#[test]
+fn it_errors_when_wasm_bindgen_is_not_declared() {
+    assert!(manifest::check_wasm_bindgen("tests/fixtures/bad-cargo-toml").is_err());
+}
+
+#[test]
+fn it_does_not_error_when_wasm_bindgen_is_declared() {
+    assert!(manifest::check_wasm_bindgen("tests/fixtures/js-hello-world").is_ok());
+}


### PR DESCRIPTION
Fixes #141

I've used the same error that's about to be merged in #150 [[error.rs]](https://github.com/ashleygwilliams/wasm-pack/pull/150/files#diff-9a269209bed069ffb36d5565a91c9840R19) to avoid duplication or further refactoring.

I guess texts may have to be reviewed as I'm not a native English speaker 😉 

Any other suggestion to improve the code will be really appreciated.
