### PR TITLE
Fix spinners

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -10,13 +10,12 @@ pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
         style("[6/7]").bold().dim(),
         emoji::DOWN_ARROW
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let output = Command::new("cargo")
         .arg("install")
         .arg("wasm-bindgen-cli")
         .arg("--force")
         .output()?;
-    pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
         if s.contains("already exists") {
@@ -40,7 +39,7 @@ pub fn wasm_bindgen_build(
         style("[7/7]").bold().dim(),
         emoji::RUNNER
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let binary_name = name.replace("-", "_");
     let wasm_path = format!("target/wasm32-unknown-unknown/release/{}.wasm", binary_name);
 
@@ -63,7 +62,6 @@ pub fn wasm_bindgen_build(
         .arg(dts_arg)
         .arg(target_arg)
         .output()?;
-    pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
         Error::cli("wasm-bindgen failed to execute properly", s)

--- a/src/build.rs
+++ b/src/build.rs
@@ -10,13 +10,12 @@ pub fn rustup_add_wasm_target() -> Result<(), Error> {
         style("[1/7]").bold().dim(),
         emoji::TARGET
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let output = Command::new("rustup")
         .arg("target")
         .arg("add")
         .arg("wasm32-unknown-unknown")
         .output()?;
-    pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
         Error::cli("Adding the wasm32-unknown-unknown target failed", s)
@@ -31,7 +30,7 @@ pub fn cargo_build_wasm(path: &str) -> Result<(), Error> {
         style("[2/7]").bold().dim(),
         emoji::CYCLONE
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let output = Command::new("cargo")
         .current_dir(path)
         .arg("build")
@@ -39,7 +38,6 @@ pub fn cargo_build_wasm(path: &str) -> Result<(), Error> {
         .arg("--target")
         .arg("wasm32-unknown-unknown")
         .output()?;
-    pb.finish();
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
         Error::cli("Compilation of your program failed", s)

--- a/src/command.rs
+++ b/src/command.rs
@@ -133,11 +133,6 @@ pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), Error
         }
     }
 
-    // Make sure we always clear the progress bar before we abort the program otherwise
-    // stderr and stdout output get eaten up and nothing will work. If this part fails
-    // to work and clear the progress bars then you're really having a bad day with your tools.
-    PBAR.done()?;
-
     // Return the actual status of the program to the main function
     status
 }
@@ -151,10 +146,9 @@ pub fn create_pkg_dir(path: &str) -> result::Result<(), Error> {
         style("[3/7]").bold().dim(),
         emoji::FOLDER
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let pkg_dir_path = format!("{}/pkg", path);
     fs::create_dir_all(pkg_dir_path)?;
-    pb.finish();
     Ok(())
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -111,7 +111,7 @@ pub fn write_package_json(
         )
     };
 
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let pkg_file_path = format!("{}/pkg/package.json", path);
     let mut pkg_file = File::create(pkg_file_path)?;
     let crate_data = read_cargo_toml(path)?;
@@ -129,7 +129,6 @@ pub fn write_package_json(
 
     let npm_json = serde_json::to_string_pretty(&npm_data)?;
     pkg_file.write_all(npm_json.as_bytes())?;
-    pb.finish();
     Ok(())
 }
 

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -1,7 +1,7 @@
 use console::style;
 use emoji;
-use std::sync::RwLock;
 use indicatif::{ProgressBar, ProgressStyle};
+use std::sync::RwLock;
 
 pub struct ProgressOutput {
     spinner: RwLock<ProgressBar>,

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -11,12 +11,11 @@ pub fn copy_from_crate(path: &str) -> Result<(), Error> {
         style("[5/7]").bold().dim(),
         emoji::DANCERS
     );
-    let pb = PBAR.message(&step);
+    PBAR.message(&step);
     let crate_readme_path = format!("{}/README.md", path);
     let new_readme_path = format!("{}/pkg/README.md", path);
     if let Err(_) = fs::copy(&crate_readme_path, &new_readme_path) {
         PBAR.warn("origin crate has no README");
     };
-    pb.finish();
     Ok(())
 }


### PR DESCRIPTION
This is an attempt to fix #145.

Since I'm new to rust there are a few things I'm not sure about, e.g. the use of RwLock to not have to deal with mutable ProgressOutput instance in the rest of the codebase and how to properly cache the infos/warnings/errors until the spinner is finished. If there are better ways - some pointers in the right direction would be appreciated.

This is not my first attempt to fix the spinners, but it is the first one that does not cause more problems than it solves:

* Using multibar does not work properly while running a child process.
* Instantiating a new spinner and not add it to a multibar breaks as soon an error/warning/info is emitted. The last of these immediate outputs will get absorbed by the spinner as well (see example in #145).
* Keeping a single spinner the whole time and using the indicatif prefix feature to keep the previous spinners output as well as infos/warnings/errors did not work out so well either: The prefix would be output again and again on every tick of a spinner, spamming the terminal.


Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your cloned directory set to nightly
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Thanks for creating/maintaining wasm-pack :)