### PR TITLE
Fix broken links to rust-lang-nursery/rust-wasm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 If you are trying to use `wasm-pack` and run into an issue- please file an
 issue! We'd love to get you up and running, even if the issue you have might
 not be directly related to the code in `wasm-pack`. This tool seeks to make
-it easy for developers to get going, so there's a good chance we can do 
+it easy for developers to get going, so there's a good chance we can do
 something to alleviate the issue by making `wasm-pack` better documented or
 more robust to different developer environments.
 
@@ -67,5 +67,5 @@ cargo +nightly fmt
 As mentioned in the readme file, this project is a part of the [`rust-wasm` working group],
 an official working group of the Rust project. We follow the Rust [Code of Conduct and enforcement policies].
 
-[`rust-wasm` working group]: https://github.com/rust-lang-nursery/rust-wasm
+[`rust-wasm` working group]: https://github.com/rustwasm/team
 [Code of Conduct and enforcement policies]: CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ This tool seeks to be a one-stop shop for building and working with rust-
 generated WebAssembly that you would like to interop with JavaScript, in the
 browser or with Node.js. `wasm-pack` helps you build and publish rust-generated
 WebAssembly to the npm registry to be used alongside any other javascript
-package in workflows that you already use, such as a bundler like 
+package in workflows that you already use, such as a bundler like
 [webpack] or [greenkeeper].
 
 [bundler-support]: https://github.com/rustwasm/team/blob/master/goals/bundler-integration.md#details
 [webpack]: https://webpack.js.org/
-[greenkeeper]: https://greenkeeper.io/ 
+[greenkeeper]: https://greenkeeper.io/
 
 This project is a part of the [rust-wasm] group. You can find more info by
 visiting that repo!
 
-[rust-wasm]: https://github.com/rust-lang-nursery/rust-wasm/
+[rust-wasm]: https://github.com/rustwasm/team
 
 ![demo](demo.gif)
 
@@ -94,5 +94,5 @@ check out our [contribution policy].
 8. To publish to npm, run `wasm-pack publish`. You may need to login to the
   registry you want to publish to. You can login using `wasm-pack login`.`
 
-[rust-wasm/36]: https://github.com/rust-lang-nursery/rust-wasm/issues/36
+[rust-wasm/36]: https://github.com/rustwasm/team/issues/36
 [wasm-bindgen]: https://github.com/alexcrichton/wasm-bindgen

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -24,6 +24,6 @@ You will need to create an npm account if you plan on publishing your package to
 the npm public registry. You can find information about signing up for npm
 [here][npm-signup-info].
 
-[rust-wasm-install-info]: https://rust-lang-nursery.github.io/rust-wasm/setup.html
+[rust-wasm-install-info]: https://rustwasm.github.io/book/setup.html
 [npm-install-info]: https://www.npmjs.com/get-npm
 [npm-signup-info]: https://www.npmjs.com/signup


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

closes #183
